### PR TITLE
Add a button to send test notification to all devices

### DIFF
--- a/app/src/main/java/dev/patri9ck/a2ln/main/ui/SettingsFragment.java
+++ b/app/src/main/java/dev/patri9ck/a2ln/main/ui/SettingsFragment.java
@@ -1,5 +1,7 @@
 package dev.patri9ck.a2ln.main.ui;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -10,10 +12,25 @@ import android.view.ViewGroup;
 
 import androidx.fragment.app.Fragment;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+
 import dev.patri9ck.a2ln.R;
 import dev.patri9ck.a2ln.databinding.FragmentSettingsBinding;
+import dev.patri9ck.a2ln.notification.NotificationSender;
+import dev.patri9ck.a2ln.notification.ParsedNotification;
 
 public class SettingsFragment extends Fragment {
+
+    private void sendTestNotification() {
+        SharedPreferences sharedPreferences = getContext().getSharedPreferences(getString(R.string.preferences_key), Context.MODE_PRIVATE);
+
+        NotificationSender notificationSender = new NotificationSender(new ArrayList<>(sharedPreferences.getStringSet(getString(R.string.preferences_addresses_key), new HashSet<>())));
+
+        ParsedNotification notification = ParsedNotification.makeTestNotification();
+
+        notificationSender.sendParsedNotification(notification);
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -21,6 +38,7 @@ public class SettingsFragment extends Fragment {
 
         binding.permissionsButton.setOnClickListener(view -> startActivity(new Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)));
         binding.helpButton.setOnClickListener(view -> startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.help_url)))));
+        binding.testButton.setOnClickListener(view -> sendTestNotification());
 
         return binding.getRoot();
     }

--- a/app/src/main/java/dev/patri9ck/a2ln/notification/ParsedNotification.java
+++ b/app/src/main/java/dev/patri9ck/a2ln/notification/ParsedNotification.java
@@ -23,6 +23,10 @@ public class ParsedNotification {
         this.icon = icon;
     }
 
+    public static ParsedNotification makeTestNotification() {
+        return new ParsedNotification("Test", "This is a test notification.", null);
+    }
+
     public static ParsedNotification parseNotification(Notification notification, Context context) {
         Object title = notification.extras.get(Notification.EXTRA_TITLE);
         Object text = notification.extras.get(Notification.EXTRA_TEXT);

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -16,4 +16,9 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/widget_margin"
         android:text="@string/help"/>
+    <Button android:id="@+id/test_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/widget_margin"
+        android:text="@string/test"/>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="removed_address">Address removed</string>
     <string name="removed_address_undo">Undo</string>
     <string name="permission">Permission</string>
+    <string name="test">Send a test notification</string>
     <string name="help">Help</string>
     <string name="title_devices">Devices</string>
     <string name="title_apps">Apps</string>


### PR DESCRIPTION
Add a button to send a test notification to all configured devices. Useful for troubleshooting.